### PR TITLE
Fix: Update to React 18 createRoot API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,13 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './Components/App/App.js';
 import registerServiceWorker from './registerServiceWorker';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
 registerServiceWorker();


### PR DESCRIPTION
The application was showing a blank page and a 'o.render is not a function' error after dependencies were updated to React 18+. This was due to the continued use of the legacy `ReactDOM.render` API.

This commit updates `src/index.js` to use the new React 18 `createRoot` API:
- Changed `react-dom` import to `react-dom/client`.
- Implemented `ReactDOM.createRoot(document.getElementById('root')).render()`
- Wrapped the `App` component in `<React.StrictMode>` for better development practices.

You should delete `node_modules` and `package-lock.json` (or `yarn.lock`) and reinstall dependencies to ensure the changes take effect.